### PR TITLE
[OSS-647] v1.0.0 of Governance Policy for /goldmansachs hosted open source projects

### DIFF
--- a/profile/GOVERNANCE.md
+++ b/profile/GOVERNANCE.md
@@ -1,25 +1,26 @@
 # Project Governance
 ## Maintainers 
 ### What's a Maintainer?
-Maintainers are those individuals who have write access or above in GitHub -- i.e., individuals with write access to protected branches (e.g., `main`) and in turn who can accept and merge pull requests into those branches. In most open source projects, maintainers act as a de facto board of directors who set the direction of the projects by din of their ability to commit changes. 
+Maintainers are open source contributors who have been granted write access (or above -- `Maintain` or `Admin` level in GitHub) entitlements to the project's repository, specifically write access to protected branches (e.g., the `main` branch). This write level access to protected branches imparts upon the maintainer the ability to accept and merge pull requests from other contributors into these protected branches. In most open source projects, maintainers act as a de facto board of directors who set the direction of the projects, and together do collaborative product management, by din of their ability to commit changes. 
 
 ### Maintainer Selection for projects in the `goldmansachs` GitHub organization
 New maintainers are elected by a majority vote of the existing maintainers. If there are an even number of maintainers than a tie vote means the new maintainer is not elected. 
 
+### Goldman Sachs Maintainer Requirement
+All projects hosted in the [`goldmansachs` GitHub org](https://github.com/goldmansachs) must have at all times at least one maintainer who is a GS employee. In the event the only GS employee-maintainer leaves Goldman Sachs, an employee-maintainer will be appointed by the Managing Director (MD) for Open Source matters for Goldman Sachs or the Open Source Program Office Lead (who themselves may serve in this capacity if an interested employee cannot be readily identified), at until such time that another GS employee can be elected as maintainer by the remainder of the maintainer community. 
+
 ### Maintainer Removal
 * Resignation by the maintainer her/him/themself from their maintainer duties
-* Resignation by maintainer who is also a GS employee from the firm
+* Resignation by a maintainer who is also a Goldman Sachs employee from their employment at Goldman Sachs 
+    * If upon resignation of a Goldman Sachs employee-maintainer from the firm, the remaining maintainers may choose to "re-elect" that individual as a maintainer to continue on as a maintainer outside of their Goldman Sachs capacity.
 * Majority vote of the other maintainers 
-    * If there are an even number of maintainers (other than the candidate for removal) than a tie vote means the new maintainer is not removed.
-* At the discretion of the MD for Open Source matters or the Open Source Program Office Lead at Goldman Sachs. 
-
-### Goldman Sachs Maintainer Requirement
-All projects hosted in the [`goldmansachs` GitHub org](https://github.com/goldmansachs) must have at all times at least one maintainer who is a GS employee. In the event the only GS employee-maintainer leaves GS, a new GS employee-maintainer will be appointed by the MD for Open Source matters for Goldman Sachs or the Open Source Program Office Lead (who themselves may serve in this capacity if an interested employee can not be readily identified).
+    * If there are an even number of maintainers (other than the candidate for removal) than a tie vote means the maintainer is not removed.
+* At the discretion of the Goldman Sachs Managing Director (MD) for Open Source matters or the Goldman Sachs Open Source Program Office Lead at Goldman Sachs, especially and in particular for any cases that may arise where Goldman Sachs deems that a maintainer's continued write access to a repository might present some level of unacceptable risk. 
 
 ### Maintainer Meetings
-The maintainers of projects hosted in the [`goldmansachs` GitHub org](https://github.com/goldmansachs) are expected to meet once per quarter to review on-going developer and progress of their projects, the project roadmap, etc.
+The maintainers of projects hosted in the [`goldmansachs` GitHub org](https://github.com/goldmansachs) are expected to meet once per quarter to review on-going development and progress of their projects, the project roadmap, etc.
 
-Projects that do not hold such a maintainer meeting two quarter in row will be deemed candidates for archiving by the Goldman Sachs Open Source Program Office
+Projects that do not hold such a maintainer meeting two quarters in row will be deemed candidates for archiving by the Goldman Sachs Open Source Program Office.
 
 
 ## Appeals and Questions

--- a/profile/GOVERNANCE.md
+++ b/profile/GOVERNANCE.md
@@ -1,0 +1,26 @@
+# Project Governance
+## Maintainers 
+### What's a Maintainer?
+Maintainers are those individuals who have write access or above in GitHub -- i.e., individuals with write access to protected branches (e.g., `main`) and in turn who can accept and merge pull requests into those branches. In most open source projects, maintainers act as a de facto board of directors who set the direction of the projects by din of their ability to commit changes. 
+
+### Maintainer Selection for projects in the `goldmansachs` GitHub organization
+New maintainers are elected by a majority vote of the existing maintainers. If there are an even number of maintainers than a tie vote means the new maintainer is not elected. 
+
+### Maintainer Removal
+* Resignation by the maintainer her/him/themself from their maintainer duties
+* Resignation by maintainer who is also a GS employee from the firm
+* Majority vote of the other maintainers 
+    * If there are an even number of maintainers (other than the candidate for removal) than a tie vote means the new maintainer is not removed.
+* At the discretion of the MD for Open Source matters or the Open Source Program Office Lead at Goldman Sachs. 
+
+### Goldman Sachs Maintainer Requirement
+All projects hosted in the [`goldmansachs` GitHub org](https://github.com/goldmansachs) must have at all times at least one maintainer who is a GS employee. In the event the only GS employee-maintainer leaves GS, a new GS employee-maintainer will be appointed by the MD for Open Source matters for Goldman Sachs or the Open Source Program Office Lead (who themselves may serve in this capacity if an interested employee can not be readily identified).
+
+### Maintainer Meetings
+The maintainers of projects hosted in the [`goldmansachs` GitHub org](https://github.com/goldmansachs) are expected to meet once per quarter to review on-going developer and progress of their projects, the project roadmap, etc.
+
+Projects that do not hold such a maintainer meeting two quarter in row will be deemed candidates for archiving by the Goldman Sachs Open Source Program Office
+
+
+## Appeals and Questions
+Appeals and questions may be directed to the [Open Source Program Office by email](opensource@gs.com).


### PR DESCRIPTION
[OSS-647] --> "Governance policy, including for maintainer selection, created for open source projects hosted in `/goldmansachs` GitHub Org". v1.0.0